### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: GeoNorge
+repo_types: [PublicClient]
+platforms: [OS_VM]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "Geonorge.Register"
+  tags:
+  - "public"
+spec:
+  type: "website"
+  lifecycle: "production"
+  owner: "datadeling_og_distribusjon"
+  system: "geonorge"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_Geonorge.Register"
+  title: "Security Champion Geonorge.Register"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "dagolav"
+  children:
+  - "resource:Geonorge.Register"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "Geonorge.Register"
+  links:
+  - url: "https://github.com/kartverket/Geonorge.Register"
+    title: "Geonorge.Register på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_Geonorge.Register"
+  dependencyOf:
+  - "component:Geonorge.Register"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: GeoNorge`
- `repo_types: [PublicClient]`
- `platforms: [OS_VM]`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.